### PR TITLE
chore: rename project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Clone the repository with Git.
 
 ```sh
-git clone https://github.com/tldr-pages/tldr-pages-dataset-gen.git
+git clone https://github.com/tldr-pages/tldr-translation-pairs-gen.git
 ```
 
 As this is a Node.js project and uses NPM for package management, start by installing dependencies.
@@ -34,7 +34,7 @@ You can run this manually over a local copy of tldr-pages. First clone a copy of
 git clone https://github.com/tldr-pages/tldr.git
 ```
 
-Then build tldr-translation-dataset-gen:
+Then build tldr-translation-pairs-gen:
 
 ```sh
 npm run build
@@ -43,7 +43,7 @@ npm run build
 Finally, you can execute the command from the transpiled sources.
 
 ```sh
-npm run tldr-translation-dataset-gen -- -s {PATH_TO_TLDR-PAGES} -o dataset.csv -O
+npm run tldr-translation-pairs-gen -- -s {PATH_TO_TLDR-PAGES} -o dataset.csv -O
 ```
 
 Read the README or help command for more information on how to use this and arguments.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
-  <h1>tldr-translation-dataset-gen</h1>
+  <h1>tldr-translation-pairs-gen</h1>
 
 [![Gitter chat][gitter-image]][gitter-url]
 [![license][license-image]][license-url]
 
 [gitter-url]: https://gitter.im/tldr-pages/tldr
 [gitter-image]: https://img.shields.io/badge/chat-on_gitter-deeppink
-[license-url]: https://github.com/tldr-pages/tldr-translation-dataset-gen/blob/main/LICENSE.md
+[license-url]: https://github.com/tldr-pages/tldr-translation-pairs-gen/blob/main/LICENSE.md
 [license-image]: https://img.shields.io/badge/license-MIT-blue.svg
 </div>
 
@@ -30,18 +30,18 @@ One way or another, obtain a copy of the tldr-pages. The easiest way is to use [
 git clone https://github.com/tldr-pages/tldr.git
 ```
 
-### Execute tldr-translation-dataset-gen
+### Execute tldr-translation-pairs-gen
 
-Once you have tldr-pages locally, you should be able to point tldr-translation-dataset-gen to the directory using the `--source` argument. This will export a `dataset.xml` file with all mappings that can be found between translated pages.
+Once you have tldr-pages locally, you should be able to point tldr-translation-pairs-gen to the directory using the `--source` argument. This will export a `dataset.xml` file with all mappings that can be found between translated pages.
 
 ```sh
-tldr-translation-dataset-gen --source {{path/to/sources}}
+tldr-translation-pairs-gen --source {{path/to/sources}}
 ```
 
 You can also pass a `--output` argument to specify a different file location. The supported file formats are CSV, JSON, and XML, which can be specified by using the appropriate file extension in the output argument.
 
 ```sh
-tldr-translation-dataset-gen --source {{path/to/sources}} --output dataset.json
+tldr-translation-pairs-gen --source {{path/to/sources}} --output dataset.json
 ```
 
 ## Excluded Strings

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "tldr-translation-dataset-gen",
+  "name": "tldr-translation-pairs-gen",
   "version": "0.1.0",
   "description": "Generates a structured dataset in various formats derived from tldr-pages.",
   "bin": {
-    "tldr-translation-dataset-gen": "./dist/index.js"
+    "tldr-translation-pairs-gen": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
     "test": "mocha -r ts-node/register 'tests/**/*.ts'",
-    "tldr-translation-dataset-gen": "node ./dist/index.js"
+    "tldr-translation-pairs-gen": "node ./dist/index.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tldr-pages/tldr-translation-dataset-gen.git"
+    "url": "git+https://github.com/tldr-pages/tldr-translation-pairs-gen.git"
   },
   "keywords": [
     "tldr",
@@ -24,9 +24,9 @@
   "author": "tldr",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tldr-pages/tldr-translation-dataset-gen/issues"
+    "url": "https://github.com/tldr-pages/tldr-translation-pairs-gen/issues"
   },
-  "homepage": "https://github.com/tldr-pages/tldr-translation-dataset-gen#readme",
+  "homepage": "https://github.com/tldr-pages/tldr-translation-pairs-gen#readme",
   "dependencies": {
     "commander": "^9.3.0",
     "csv-stringify": "^6.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ import { execute } from './lib/lib';
 
 const version = '0.1.0';
 
-const program = new Command('tldr-translation-dataset-gen');
+const program = new Command('tldr-translation-pairs-gen');
 
 program
-  .name('tldr-translation-dataset-get')
+  .name('tldr-translation-pairs-gen')
   .addHelpText('before', `Version: ${version}`)
   .addHelpText('before', 'Copyright (c) 2022-present tldr-pages team and contributors')
   .description(`Generates a translation dataset derived from tldr-pages with support for various formats`)


### PR DESCRIPTION
Renames the project from `tldr-pages-dataset-gen` to `tldr-translation-pairs-gen`.

I noticed in the repo/project I was using two names. :facepalm: 
* tldr-translation-dataset-gen
* tldr-pages-dataset-gen

This also gets us aligned here. ^-^'

Are we happy with this name or do we want something else?

Reading back in Matrix, not sure if the proposal was meant to be `tldr-translation-pairs-gen` or `tldr-pages-translation-pairs-gen`. Either way it's a bit long, but welcome to let me know in this PR before we merge!