### PR TITLE
fix: don't crash on unexpected directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tldr-translation-pairs-gen",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tldr-translation-pairs-gen",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.3.0",
@@ -43,18 +43,18 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -170,9 +170,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
-      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -812,9 +812,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldr-translation-pairs-gen",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Generates a structured dataset in various formats derived from tldr-pages.",
   "bin": {
     "tldr-translation-pairs-gen": "./dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,11 +51,7 @@ async function process() {
   try {
     await execute(source, absOutputPath, format);
   } catch (error) {
-    if (error instanceof Error) {
-      console.error(`ERROR: ${error.message}`);
-      return;
-    }
-
+    console.error("\nFATAL: Internal error occurred! Please file a bug report and include terminal output:\nhttps://github.com/tldr-pages/tldr-translation-pairs-gen/issues/new\n");
     throw error;
   }
 }

--- a/src/lib/tldr-file.ts
+++ b/src/lib/tldr-file.ts
@@ -45,11 +45,23 @@ export class TldrFile {
   /**
    * Reads the tldr page from disk.
    *
-   * @returns
+   * @returns Contents of the tldr page.
    */
   public async read(): Promise<TldrPage> {
     const pageString = await fs.promises.readFile(this.path, 'utf8');
     const tldrPage = parseTldrPage(pageString);
     return tldrPage;
+  }
+
+  /**
+   * Perform checks to ensure there is nothing unexpected about the tldr page.
+   * This attempts to catch errors that occur in the tldr repository and work
+   * around them to avoid crashes.
+   *
+   * @returns If the file is fine to process.
+   */
+  public async verifyIntegrity(): Promise<boolean> {
+    const stats = await fs.promises.lstat(this.path);
+    return !stats.isDirectory();
   }
 }


### PR DESCRIPTION
In the tldr repo, we accidentally merged a PR with the wrong file structure.

This led tldr-translations-pairs-gen to crash. To avoid this from happening again, I added a `verifyIntegrity` function where can perform any checks on the file and make sure we're happy to process it. Currently, it just checks if it's a directory that logs a warning and skips it if so.

### Related

* https://github.com/tldr-pages/tldr/pull/9984/files