### PR TITLE
chores: fix link and add jsdocs to functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ However, sometimes after removing the content between curly braces, two or more 
 
 Here is a real-world example of the problem: the English version was modified after the French translation was made, so now the pages have fallen out of sync. If we made pairs using the index, we'd create mismatches.
 
-| [EN](https://github.com/tldr-pages/tldr/blob/77decbbb90597baa942e224da2138477d273fc86/pages/common/tldr.md) | [FR](https://github.com/SethFalco/tldr/blob/051d085b7b684aec7413e2ea2ea36cc24406ce16/pages.fr/common/tldr.md) |
+| [EN](https://github.com/tldr-pages/tldr/blob/77decbbb90597baa942e224da2138477d273fc86/pages/common/tldr.md) | [FR](https://github.com/tldr-pages/tldr/blob/77decbbb90597baa942e224da2138477d273fc86/pages.fr/common/tldr.md) |
 |---|---|
 | - Print the tldr page for a specific command (hint: this is how you got here!): <br><br> `tldr {{command}}` | - Affiche la page tldr d'une commande (indice : c'est comme ça que vous êtes arrivé ici !) : <br><br> `tldr {{commande}}`
 | - Print the tldr page for a specific subcommand: <br><br> `tldr {{command}}-{{subcommand}}` | - Affiche la page tldr de `cd`, en forçant la plateforme par défaut : <br><br> `tldr -p {{android\|linux\|osx\|sunos\|windows}} {{cd}}`

--- a/src/lib/lib.ts
+++ b/src/lib/lib.ts
@@ -7,9 +7,19 @@ import { TldrPage } from '../lib/tldr-page';
 import { Example, LanguageMapping, Writer } from '../types/tldr-pages';
 import { getWriterForFile } from '../writers/writer-factory';
 
+/**
+ * Matches token in tldr pages. Tokens are wrapped in curly braces, and have a
+ * prefix of "{{" and suffix of "}}".
+ */
 const TOKEN_PATTERN = /(?<=\{\{)[^{]+?(?=\}\})/g;
+
+/** String to replace token syntax with during normalization. */
 const TOKEN_NORMALIZED = '…';
 
+/**
+ * @param source Path to search for tldr pages from.
+ * @returns Array of paths to tldr pages.
+ */
 function collectTldrPages(source: string): Promise<string[]> {
   const globAsync = promisify(glob);
   return globAsync(`${source}/pages*/**/*.md`);
@@ -23,6 +33,10 @@ function getSupportedLanguages(tldrPageFiles: TldrFile[]): Set<string> {
   return new Set(languages);
 }
 
+/**
+ * @param tldrPages Paths to tldr pages.
+ * @returns Metadata of the tldr pages by parsing the file path.
+ */
 export function parseTldrPaths(tldrPages: string[]): TldrFile[] {
   return tldrPages.map((page) => {
     const absolutePath = path.resolve(page);
@@ -126,8 +140,12 @@ export function unique<T>(array: T[], predicate: (a: T, b: T) => boolean) {
   }, []);
 }
 
-export function normalize(text: string) {
-  return text.replace(TOKEN_PATTERN, TOKEN_NORMALIZED);
+/**
+ * @param body Arbitrary string to normalize.
+ * @returns New string where all token syntax is replaced with a predictable string.
+ */
+export function normalize(body: string) {
+  return body.replace(TOKEN_PATTERN, TOKEN_NORMALIZED);
 }
 
 export function findTranslations(sourcePage: TldrPage, sourceLanguage: string, targetPage: TldrPage, targetLanguage: string): LanguageMapping[] {
@@ -254,8 +272,8 @@ export async function execute(source: string, output: string, targetFormat: stri
 }
 
 /**
- * Note that while each combination in the array is sorted, the top-level array
- * itself is not.
+ * While each combination in the array is sorted, the top-level array itself is
+ * not.
  *
  * @param arr Any arbitrary array of items.
  * @returns All combinations of 2 items in the list, each individual combination sorted.


### PR DESCRIPTION
* Fix a link in the README which was pointing to my fork (and at the wrong commit) instead of the main repo.
* Add some JSDocs to clarify some of the helper functions.