### PR TITLE
deps: upgrade to latest v4 release of chai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,12 @@
         "tldr-translation-pairs-gen": "dist/index.js"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.11",
+        "@types/chai": "^4.3.12",
         "@types/glob": "^8.0.0",
         "@types/marked": "^4.0.7",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.15",
-        "chai": "^4.3.10",
+        "chai": "^4.4.1",
         "mocha": "^10.3.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
@@ -136,9 +136,9 @@
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
-      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.12.tgz",
+      "integrity": "sha512-zNKDHG/1yxm8Il6uCCVsm+dRdEsJlFoDu73X17y09bId6UwoYww+vFBsAcRzl8knM1sab3Dp1VRikFQwDOtDDw==",
       "dev": true
     },
     "node_modules/@types/glob": {
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "xmlbuilder2": "^3.1.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.11",
+    "@types/chai": "^4.3.12",
     "@types/glob": "^8.0.0",
     "@types/marked": "^4.0.7",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.15",
-    "chai": "^4.3.10",
+    "chai": "^4.4.1",
     "mocha": "^10.3.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"


### PR DESCRIPTION
Chai v5 is a breaking release that drops CJS support. I'm not sure why yet, but for now, I'm having trouble upgrading to v5 due to issues with how we've configured it with TypeScript.

At first, I thought it was because tsconfig is configured to produce CJS, but despite setting it to esnext, it still has issues.

We'll upgrade to v5 later, but for now we can upgrade to the latest v4 release, which continues to be maintained. In future, we'll hopefully see more documentation available that helps with our setup.

## Related

* Closes https://github.com/tldr-pages/tldr-translation-pairs-gen/pull/42